### PR TITLE
metriq-app issue 2: Add JWT to /api/register

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,4 +13,10 @@ config.api.getUriPrefix = () => {
     return config.api.protocol + config.api.url + config.api.endpoint;
 };
 
+config.api.token = {};
+// NEVER store a valid secret key in files that might be checked into source code repositories!!!
+config.api.token.secretKey = config.isDebug ? require('crypto').randomBytes(256).toString('base64') : process.env.METRIQ_SECRET_KEY;
+// Token is valid for 60 minutes (unless refreshed).
+config.api.token.expiresIn = 60;
+
 module.exports = config;

--- a/controller/registerController.js
+++ b/controller/registerController.js
@@ -21,7 +21,8 @@ exports.new = async function (req, res) {
         if (result.success) {
             res.json({
                 message: 'New account created!',
-                data: result.body
+                data: result.body,
+                token: await userService.generateUserJwt(result.body._id)
             }).end();
             return;
         }

--- a/index.js
+++ b/index.js
@@ -25,9 +25,9 @@ var db = mongoose.connection;
 
 // Add a check for DB connection.
 if (!db) {
-    console.log("Error while connecting to db")
+    console.log("Error while connecting to db");
 } else {
-    console.log("Db connection successful")
+    console.log("Db connection successful");
 }
 
 // Set up the server port.

--- a/service/userService.js
+++ b/service/userService.js
@@ -10,6 +10,10 @@ const bcrypt = require('bcrypt');
 const e = require("express");
 const saltRounds = 10;
 
+let jwt = require('jsonwebtoken');
+// Config for JWT secret key
+let config = require('./../config');
+
 class UserService {
     constructor() {
         this.MongooseServiceInstance = new MongooseService(UserModel);
@@ -22,6 +26,10 @@ class UserService {
         } catch ( err ) {
             return { success: false, error: err };
         }
+    }
+
+    async generateUserJwt(userId) {
+        return jwt.sign({ id: userId }, config.api.token.secretKey, { expiresIn: config.api.token.expiresIn });
     }
 
     async getByUsername(username) {


### PR DESCRIPTION
This addresses today's changes to the user story in [metriq-app issue 2](https://github.com/unitaryfund/metriq-app/issues/2). (For branch/PR tracking purposes, we might want to keep API user stories as issues in this repository, by the way.)

The token isn't used, yet, but this adds a JWT to the return JSON from `/api/register`. I think it goes without saying, but _**DO NOT EVER STORE SECRET KEYS IN CONFIG FILES**_, including _**any**_ file which might be checked into the source code repository. For now, we just generate a new debug secret key every time the app starts, and we expect to load the production environment key from the production environment shell instance. However, the random debug key might become a pain, since tokens won't be maintained on restart. If so, we'll probably just _always_ load a secret key from any given local environment shell, and _never_ provide a real key for _any_ environment; you just make your own up.