### PR TITLE
28 Allow user to change password.

### DIFF
--- a/api-routes.js
+++ b/api-routes.js
@@ -30,6 +30,8 @@ router.route('/user')
   .delete(userController.delete)
 router.route('/submission')
   .put(submissionController.new)
+router.route('/user/password')
+  .post(accountController.newPassword)
 
 // Export API routes.
 module.exports = router

--- a/controller/accountController.js
+++ b/controller/accountController.js
@@ -89,7 +89,7 @@ exports.newToken = async function (req, res) {
     false)
 }
 
-// Delete any client token for the user ID claim
+// Delete any client token for the user ID claim.
 exports.deleteToken = async function (req, res) {
   if (req.user.role !== 'web') {
     sendResponse(res, 403, 'Authorization role lacks privileges.')
@@ -100,4 +100,17 @@ exports.deleteToken = async function (req, res) {
     async () => await userService.deleteClientTokenForUserId(req.user.id),
     'Client token was deleted successfully.',
     false)
+}
+
+// Allow client to change password for the user ID claim.
+exports.newPassword = async function (req, res) {
+  if (req.user.role !== 'web') {
+    sendResponse(res, 403, 'Authorization role lacks privileges.')
+    return
+  }
+
+  routeWrapper(res,
+    async () => await userService.changePassword(req),
+    'Password was changed successfully.',
+    true)
 }

--- a/model/submissionModel.js
+++ b/model/submissionModel.js
@@ -18,7 +18,7 @@ const submissionSchema = mongoose.Schema({
   submissionNameNormal: {
     type: String,
     required: true,
-    unique: true,
+    unique: true
   },
   submittedDate: {
     type: Date,

--- a/service/userService.js
+++ b/service/userService.js
@@ -239,6 +239,28 @@ class UserService {
 
     return { success: true, body: '' }
   }
+
+  async changePassword (reqBody) {
+    const users = await this.getByUserId(reqBody.id)
+    if (!users || !users.length) {
+      return { success: false, error: 'User not found.' }
+    }
+
+    const user = users[0]
+
+    if (!reqBody.password || (reqBody.password.length < 8)) {
+      return { success: false, error: 'Password is too short.' }
+    }
+
+    if (!reqBody.passwordConfirm || (reqBody.password !== reqBody.passwordConfirm)) {
+      return { success: false, error: 'Password and confirmation do not match.' }
+    }
+
+    user.passwordHash = await bcrypt.hash(reqBody.password, saltRounds)
+    await user.save()
+
+    return { success: true }
+  }
 }
 
 module.exports = UserService


### PR DESCRIPTION
#28 Allow user to alter password via API.

- Added new route `/user/password`
- Added function `changePassword` to allow user to change password if validated
- Added unit tests for coverage for changing password functionality.