### PR TITLE
#54: Get popular, by tag

### DIFF
--- a/api-routes.js
+++ b/api-routes.js
@@ -47,6 +47,8 @@ router.route('/submission/popular/:page')
   .get(submissionController.popular)
 router.route('/submission/latest/:page')
   .get(submissionController.latest)
+router.route('/submission/:tag/popular/:page')
+  .get(submissionController.tagPopular)
 
 // Export API routes.
 module.exports = router

--- a/controller/submissionController.js
+++ b/controller/submissionController.js
@@ -76,3 +76,9 @@ exports.popular = async function (req, res) {
     async () => await submissionService.getPopular(parseInt(req.params.page) * itemsPerPage, itemsPerPage),
     'Retrieved top results.')
 }
+
+exports.tagPopular = async function (req, res) {
+  routeWrapper(res,
+    async () => await submissionService.getPopularByTag(req.params.tag, parseInt(req.params.page) * itemsPerPage, itemsPerPage),
+    'Retrieved top results.')
+}

--- a/service/submissionService.js
+++ b/service/submissionService.js
@@ -130,11 +130,11 @@ class SubmissionService {
     submission.submissionNameNormal = reqBody.submissionName.trim().toLowerCase()
     submission.submittedDate = new Date()
 
-    let tags = []
+    const tags = []
     if (reqBody.tags) {
-      let tagSplit = reqBody.tags.split(",")
+      const tagSplit = reqBody.tags.split(',')
       for (let i = 0; i < tagSplit.length; i++) {
-        let tag = tagSplit[i].trim().toLowerCase()
+        const tag = tagSplit[i].trim().toLowerCase()
         if (tag) {
           tags.push(tag)
         }
@@ -254,6 +254,19 @@ class SubmissionService {
   async getPopular (startIndex, count) {
     const result = await this.MongooseServiceInstance.Collection.aggregate([
       { $match: { deletedDate: null, approvedDate: { $ne: null } } },
+      {
+        $addFields: {
+          upvotesCount: { $size: '$upvotes' }
+        }
+      },
+      { $sort: { upvotesCount: -1 } }
+    ]).skip(startIndex).limit(count)
+    return { success: true, body: result }
+  }
+
+  async getPopularByTag (tag, startIndex, count) {
+    const result = await this.MongooseServiceInstance.Collection.aggregate([
+      { $match: { deletedDate: null, approvedDate: { $ne: null }, tags: tag } },
       {
         $addFields: {
           upvotesCount: { $size: '$upvotes' }


### PR DESCRIPTION
Note that URL encoded space characters also work, (`%20`). We accept spaces in tags. (I think this is a lot more obvious, for multiple-word tags, than forcing the user to choose an ad hoc separator character.)