### PR TITLE
Skip email, if account info not set

### DIFF
--- a/service/submissionService.js
+++ b/service/submissionService.js
@@ -178,6 +178,11 @@ class SubmissionService {
       return { success: true, body: result.body }
     }
 
+    if (!config.supportEmail.service) {
+      console.log('Skipping email - account info not set.')
+      return { success: true, body: result.body }
+    }
+
     const transporter = nodemailer.createTransport({
       service: config.supportEmail.service,
       auth: {

--- a/service/userService.js
+++ b/service/userService.js
@@ -251,11 +251,15 @@ class UserService {
   }
 
   async sendRecoveryEmail (usernameOrEmail) {
+    if (!config.supportEmail.service) {
+      console.log('Skipping email - account info not set.')
+      return { success: false, error: 'Support email not available.' }
+    }
+
     const users = await this.getByUsernameOrEmail(usernameOrEmail)
     if (!users || !users.length) {
       return { success: false, error: 'User not found.' }
     }
-
     const user = users[0]
     user.generateRecovery()
 


### PR DESCRIPTION
Per https://github.com/unitaryfund/metriq-app/pull/83, if support email account info is not set, we should simply skip sending emails when possible, to lower the difficulty threshold to testing the app.