### PR TITLE
Making evaluated date non-mandatory.

### DIFF
--- a/metriq-api/model/resultModel.js
+++ b/metriq-api/model/resultModel.js
@@ -39,7 +39,7 @@ const resultSchema = mongoose.Schema({
   },
   evaluatedDate: {
     type: Date,
-    required: true
+    required: false
   },
   submittedDate: {
     type: Date,


### PR DESCRIPTION
https://github.com/unitaryfund/metriq-app/issues/101

Making the evaluated date field non-mandatory in API. 