### PR TITLE
Load half as many items per scroll view page

### DIFF
--- a/metriq-api/controller/submissionController.js
+++ b/metriq-api/controller/submissionController.js
@@ -102,7 +102,7 @@ exports.upvote = async function (req, res) {
     'Up-voted submission!')
 }
 
-const itemsPerPage = 10
+const itemsPerPage = 5
 
 exports.trending = async function (req, res) {
   routeWrapper(res,

--- a/metriq-api/model/submissionModel.js
+++ b/metriq-api/model/submissionModel.js
@@ -30,7 +30,7 @@ const submissionSchema = mongoose.Schema({
   },
   submissionContentUrl: {
     type: String,
-    required: true,
+    required: true
   },
   submissionThumbnailUrl: {
     type: String,


### PR DESCRIPTION
We could maybe carry this optimization further, but this is a start. A typical PC screen will tend to show about 4 scroll view items upon landing, so we only load 5 for the first page of any of these scroll views, in this PR.

Additionally, if we can, I'll make sure that the first view to be populate is the default tab we land on for a fresh page load. That will be in a separate PR.

The work in this PR is already up on QA.