### PR TITLE
#131: Fix typo in `Submission` DTO

### DIFF
--- a/metriq-api/service/submissionService.js
+++ b/metriq-api/service/submissionService.js
@@ -141,7 +141,7 @@ class SubmissionService {
       deletedDate: submission.deletedDate,
       tags: submission.tags,
       methods: submission.methods,
-      tasks: submission.methods,
+      tasks: submission.tasks,
       results: submission.results,
       user: submission.user,
       submissionName: submission.submissionName,


### PR DESCRIPTION
This is why we need standardized and unit-tested DTOs, by the way. (Entirely my fault, here.) See #131.