### PR TITLE
Do not create result without valid task and method.

### DIFF
--- a/metriq-api/coverage/result.test.js
+++ b/metriq-api/coverage/result.test.js
@@ -27,6 +27,24 @@ afterAll(async () => await dbHandler.closeDatabase());
  */
 describe('result', () => {
 
+    it('cannot be created if method or task is not defined', async () => {
+        // Initialize
+        const userId = (await (new UserService()).register(registration1)).body._id
+
+        const submissionService = new SubmissionService()
+        const submissionResult = await submissionService.submit(userId, submission1, false)
+
+        const submissionId = submissionResult.body._id
+
+        const resultService = new ResultService()
+
+        // Act
+       const result = await resultService.submit(userId, submissionId, result1)
+
+        // Assert
+        expect(result.success).toBe(false)
+    })
+
     it('can be created', async () => {
         // Initialize
         const userId = (await (new UserService()).register(registration1)).body._id
@@ -55,6 +73,7 @@ describe('result', () => {
         // Assert
         expect(result.success).toBe(true)
     })
+
 })
 
 const registration1 = {

--- a/metriq-api/service/resultService.js
+++ b/metriq-api/service/resultService.js
@@ -8,6 +8,10 @@ const ResultModel = require('../model/resultModel')
 // Service dependencies
 const SubmissionService = require('../service/submissionService')
 const submissionService = new SubmissionService()
+const TaskService = require('../service/taskService')
+const taskService = new TaskService()
+const MethodService = require('../service/methodService')
+const methodService = new MethodService()
 
 class ResultService {
   constructor () {
@@ -52,6 +56,26 @@ class ResultService {
     result.metricValue = reqBody.metricValue
     result.evaluatedDate = reqBody.evaluatedDate
     result.submittedDate = new Date()
+
+    // Task must be not null and valid (present in database) for a valid result object.
+    if (result.task == null) {
+      return { success: false, error: 'Result requires task to be defined.' }
+    }
+    try {
+      taskService.getById(result.task)
+    } catch (err) {
+      return { success: false, error: 'Result requires task to be present in database.' }
+    }
+
+    // Method must be not null and valid (present in database) for a valid result object.
+    if (result.method == null) {
+      return { success: false, error: 'Result requires method to be defined.' }
+    }
+    try {
+      methodService.getById(result.method)
+    } catch (err) {
+      return { success: false, error: 'Result requires method to be present in database.' }
+    }
 
     const nResult = await this.create(result)
     if (!nResult.success) {


### PR DESCRIPTION
#134 Results are prevented from being created unless valid associated task and method are provided.

- Unit test to check that result cannot be created if task and method are not supplied
- Adding a check in `resultService.js` in the `submit` method to ensure that a result is not created unless both a valid task and method are provided. 