### PR TITLE
unitaryfund/metriq-app#361: Let users edit results

### DIFF
--- a/metriq-api/api-routes.js
+++ b/metriq-api/api-routes.js
@@ -98,6 +98,7 @@ router.route('/submission/:id/result')
 router.route('/result/metricNames')
   .get(resultController.readMetricNames)
 router.route('/result/:id')
+  .post(resultController.update)
   .delete(resultController.delete)
 
 // Export API routes.

--- a/metriq-api/controller/resultController.js
+++ b/metriq-api/controller/resultController.js
@@ -38,6 +38,12 @@ exports.new = async function (req, res) {
     'New result added to submission!')
 }
 
+exports.update = async function (req, res) {
+  routeWrapper(res,
+    async () => await resultService.update(req.user.id, req.params.id, req.body),
+    'Updated method.')
+}
+
 exports.delete = async function (req, res) {
   routeWrapper(res,
     async () => await resultService.delete(req.params.id),


### PR DESCRIPTION
Per unitaryfund/metriq-app#361, these are the back end changes to let users edit results, without deleting them and adding them a second time.