### PR TITLE
unitaryfund/metriq-app#367: Indicate child tasks in SOTA chart

### DIFF
--- a/metriq-api/service/resultService.js
+++ b/metriq-api/service/resultService.js
@@ -31,12 +31,13 @@ class ResultService extends ModelService {
     '    SELECT t.id FROM tasks AS t ' +
     '    JOIN c on c.id = t."taskId" ' +
     ') ' +
-    'SELECT r.*, s.name as "submissionName", m.name as "methodName" FROM "submissionTaskRefs" AS str ' +
+    'SELECT r.*, s.name as "submissionName", CASE WHEN t.id = ' + taskId + ' THEN m.name ELSE m.name || \' |\' || t.name END as "methodName" FROM "submissionTaskRefs" AS str ' +
     '    RIGHT JOIN c on c.id = str."taskId" ' +
     '    JOIN results AS r on r."submissionTaskRefId" = str.id ' +
     '    LEFT JOIN submissions AS s on str."submissionId" = s.id ' +
     '    LEFT JOIN "submissionMethodRefs" AS smr on r."submissionMethodRefId" = smr.id ' +
     '    LEFT JOIN methods AS m on smr."methodId" = m.id ' +
+    '    LEFT JOIN tasks AS t on str."taskId" = t.id ' +
     '    WHERE str."deletedAt" IS NULL;'
   }
 


### PR DESCRIPTION
Cross-child-task comparison charts are made much clearer by also indicating the child tasks in data point labels, for any results that come from a child task level.