### PR TITLE
#384: Task/method submission visibility

### DIFF
--- a/metriq-api/service/methodService.js
+++ b/metriq-api/service/methodService.js
@@ -37,8 +37,9 @@ class MethodService extends ModelService {
 
   async getAllNamesAndCounts () {
     const result = (await sequelize.query(
-      'SELECT methods.id as id, methods.name as name, COUNT("submissionMethodRefs".*) as "submissionCount", COUNT(likes.*) as "upvoteTotal" from "submissionMethodRefs" ' +
+      'SELECT methods.id as id, methods.name as name, COUNT(DISTINCT "submissionMethodRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionMethodRefs" ' +
       'RIGHT JOIN methods on methods.id = "submissionMethodRefs"."methodId" ' +
+      'RIGHT JOIN submissions on submissions.id = "submissionMethodRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
       'LEFT JOIN likes on likes."submissionId" = "submissionMethodRefs"."submissionId" ' +
       'GROUP BY methods.id'
     ))[0]

--- a/metriq-api/service/submissionRefService.js
+++ b/metriq-api/service/submissionRefService.js
@@ -13,6 +13,10 @@ class SubmissionRefService extends ModelService {
     return await this.SequelizeServiceInstance.findOne({ submissionId: submissionId, [this.foreignKey]: fkId })
   }
 
+  async getFkCount (fkId) {
+    return await this.SequelizeServiceInstance.count({ [this.foreignKey]: fkId })
+  }
+
   async createOrFetch (submissionId, userId, fkId) {
     let ref = await this.getByFks(submissionId, fkId)
 

--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -50,8 +50,9 @@ class TaskService extends ModelService {
 
   async getAllNamesAndCounts () {
     const result = (await sequelize.query(
-      'SELECT tasks.id as id, tasks.name as name, COUNT("submissionTaskRefs".*) as "submissionCount", COUNT(likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
+      'SELECT tasks.id as id, tasks.name as name, COUNT(DISTINCT "submissionTaskRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
       'RIGHT JOIN tasks on tasks.id = "submissionTaskRefs"."taskId" ' +
+      'RIGHT JOIN submissions on submissions.id = "submissionTaskRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
       'LEFT JOIN likes on likes."submissionId" = "submissionTaskRefs"."submissionId" ' +
       'GROUP BY tasks.id'
     ))[0]


### PR DESCRIPTION
This hides not-yet-approved submissions from task and method index views, per unitaryfund/metriq-app#384.