### PR TITLE
unitaryfund/metriq-app#275: Hide methods with 0 submissions

### DIFF
--- a/metriq-api/service/methodService.js
+++ b/metriq-api/service/methodService.js
@@ -37,11 +37,13 @@ class MethodService extends ModelService {
 
   async getAllNamesAndCounts () {
     const result = (await sequelize.query(
-      'SELECT methods.id as id, methods.name as name, COUNT(DISTINCT "submissionMethodRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionMethodRefs" ' +
-      'RIGHT JOIN methods on methods.id = "submissionMethodRefs"."methodId" ' +
-      'LEFT JOIN submissions on submissions.id = "submissionMethodRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
-      'LEFT JOIN likes on likes."submissionId" = "submissionMethodRefs"."submissionId" ' +
-      'GROUP BY methods.id'
+      'SELECT * FROM (' +
+      '  SELECT methods.id as id, methods.name as name, COUNT(DISTINCT "submissionMethodRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionMethodRefs" ' +
+      '  RIGHT JOIN methods on methods.id = "submissionMethodRefs"."methodId" and "submissionMethodRefs"."deletedAt" IS NULL ' +
+      '  LEFT JOIN submissions on submissions.id = "submissionMethodRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
+      '  LEFT JOIN likes on likes."submissionId" = "submissionMethodRefs"."submissionId" ' +
+      '  GROUP BY methods.id' +
+      ') as a WHERE a."submissionCount" > 0'
     ))[0]
     return { success: true, body: result }
   }

--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -54,11 +54,13 @@ class TaskService extends ModelService {
 
   async getAllNamesAndCounts () {
     const result = (await sequelize.query(
-      'SELECT tasks.id as id, tasks.name as name, COUNT(DISTINCT "submissionTaskRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
-      'RIGHT JOIN tasks on tasks.id = "submissionTaskRefs"."taskId" ' +
-      'LEFT JOIN submissions on submissions.id = "submissionTaskRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
-      'LEFT JOIN likes on likes."submissionId" = "submissionTaskRefs"."submissionId" ' +
-      'GROUP BY tasks.id'
+      'SELECT * FROM (' +
+      '  SELECT tasks.id as id, tasks.name as name, COUNT(DISTINCT "submissionTaskRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
+      '  RIGHT JOIN tasks on tasks.id = "submissionTaskRefs"."taskId" AND  "submissionTaskRefs"."deletedAt" is NULL ' +
+      '  LEFT JOIN submissions on submissions.id = "submissionTaskRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
+      '  LEFT JOIN likes on likes."submissionId" = "submissionTaskRefs"."submissionId" ' +
+      '  GROUP BY tasks.id' +
+      ') as a WHERE a."submissionCount" > 0'
     ))[0]
     return { success: true, body: result }
   }


### PR DESCRIPTION
This closes unitaryfund/metriq-app#275. If a task or method has 0 submissions associated, it is hidden from the index pages. (Additionally, the count of _non-deleted_ submissions associated with task/method index items has been fixed.)