### PR TITLE
#414: database migrations

### DIFF
--- a/metriq-api/models/likeModel.js
+++ b/metriq-api/models/likeModel.js
@@ -2,11 +2,9 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('like', {}, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.like)
-      }
-    }
-  })
+  const Model = sequelize.define('like', {}, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.like)
+  }
+  return Model
 }

--- a/metriq-api/models/methodModel.js
+++ b/metriq-api/models/methodModel.js
@@ -2,7 +2,7 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('method', {
+  const Model = sequelize.define('method', {
     name: {
       type: DataTypes.TEXT,
       allowNull: false
@@ -15,11 +15,9 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: false
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.method)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.method)
+  }
+  return Model
 }

--- a/metriq-api/models/moderationReportModel.js
+++ b/metriq-api/models/moderationReportModel.js
@@ -2,7 +2,7 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('moderationReport', {
+  const Model = sequelize.define('moderationReport', {
     description: {
       type: DataTypes.TEXT,
       allowNull: false
@@ -10,11 +10,9 @@ module.exports = function (sequelize, DataTypes) {
     resolvedAt: {
       type: DataTypes.DATE
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.moderationReport)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.moderationReport)
+  }
+  return Model
 }

--- a/metriq-api/models/resultModel.js
+++ b/metriq-api/models/resultModel.js
@@ -2,7 +2,7 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('result', {
+  const Model = sequelize.define('result', {
     isHigherBetter: {
       type: DataTypes.BOOLEAN,
       allowNull: false
@@ -23,11 +23,9 @@ module.exports = function (sequelize, DataTypes) {
       allowNull: false,
       defaultValue: ''
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.result)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.result)
+  }
+  return Model
 }

--- a/metriq-api/models/submissionMethodRefModel.js
+++ b/metriq-api/models/submissionMethodRefModel.js
@@ -2,13 +2,11 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('submissionMethodRef', {}, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.submissionMethodRef)
-        db.submissionMethodRef.belongsTo(db.method)
-        db.submissionMethodRef.hasMany(db.result)
-      }
-    }
-  })
+  const Model = sequelize.define('submissionMethodRef', {}, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.submissionMethodRef)
+    db.submissionMethodRef.belongsTo(db.method)
+    db.submissionMethodRef.hasMany(db.result)
+  }
+  return Model
 }

--- a/metriq-api/models/submissionModel.js
+++ b/metriq-api/models/submissionModel.js
@@ -2,7 +2,7 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('submission', {
+  const Model = sequelize.define('submission', {
     name: {
       type: DataTypes.TEXT,
       allowNull: false
@@ -25,16 +25,14 @@ module.exports = function (sequelize, DataTypes) {
     approvedAt: {
       type: DataTypes.DATE
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.submission)
-        db.submission.hasMany(db.like)
-        db.submission.hasMany(db.submissionMethodRef)
-        db.submission.hasMany(db.submissionTaskRef)
-        db.submission.hasMany(db.submissionTagRef)
-        db.submission.hasMany(db.moderationReport)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.submission)
+    db.submission.hasMany(db.like)
+    db.submission.hasMany(db.submissionMethodRef)
+    db.submission.hasMany(db.submissionTaskRef)
+    db.submission.hasMany(db.submissionTagRef)
+    db.submission.hasMany(db.moderationReport)
+  }
+  return Model
 }

--- a/metriq-api/models/submissionTagRefModel.js
+++ b/metriq-api/models/submissionTagRefModel.js
@@ -2,12 +2,10 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('submissionTagRef', {}, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.submissionTagRef)
-        db.submissionTagRef.belongsTo(db.tag)
-      }
-    }
-  })
+  const Model = sequelize.define('submissionTagRef', {}, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.submissionTagRef)
+    db.submissionTagRef.belongsTo(db.tag)
+  }
+  return Model
 }

--- a/metriq-api/models/submissionTaskRefModel.js
+++ b/metriq-api/models/submissionTaskRefModel.js
@@ -5,8 +5,8 @@ module.exports = function (sequelize, DataTypes) {
   const Model = sequelize.define('submissionTaskRef', {}, {})
   Model.associate = function (db) {
     db.user.hasMany(db.submissionTaskRef)
+    db.submissionTaskRef.hasMany(db.result)
     db.submissionTaskRef.belongsTo(db.task)
-    db.submissionTaskRef.belongsTo(db.result)
   }
   return Model
 }

--- a/metriq-api/models/submissionTaskRefModel.js
+++ b/metriq-api/models/submissionTaskRefModel.js
@@ -2,13 +2,11 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('submissionTaskRef', {}, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.submissionTaskRef)
-        db.submissionTaskRef.belongsTo(db.task)
-        db.submissionTaskRef.belongsTo(db.result)
-      }
-    }
-  })
+  const Model = sequelize.define('submissionTaskRef', {}, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.submissionTaskRef)
+    db.submissionTaskRef.belongsTo(db.task)
+    db.submissionTaskRef.belongsTo(db.result)
+  }
+  return Model
 }

--- a/metriq-api/models/tagModel.js
+++ b/metriq-api/models/tagModel.js
@@ -2,16 +2,14 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('tag', {
+  const Model = sequelize.define('tag', {
     name: {
       type: DataTypes.TEXT,
       allowNull: false
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.tag)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.tag)
+  }
+  return Model
 }

--- a/metriq-api/models/taskModel.js
+++ b/metriq-api/models/taskModel.js
@@ -2,7 +2,7 @@
 
 'use strict'
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('task', {
+  const Model = sequelize.define('task', {
     name: {
       type: DataTypes.TEXT,
       allowNull: false
@@ -15,12 +15,10 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: false
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.task)
-        db.task.belongsTo(db.task)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.task)
+    db.task.belongsTo(db.task)
+  }
+  return Model
 }

--- a/metriq-api/models/userModel.js
+++ b/metriq-api/models/userModel.js
@@ -7,7 +7,7 @@ const recoveryExpirationMinutes = 30
 const millisPerMinute = 60000
 
 module.exports = function (sequelize, DataTypes) {
-  return sequelize.define('user', {
+  const Model = sequelize.define('user', {
     username: {
       type: DataTypes.TEXT,
       allowNull: false
@@ -41,16 +41,14 @@ module.exports = function (sequelize, DataTypes) {
     recoveryTokenExpiration: {
       type: DataTypes.DATE
     }
-  }, {
-    classMethods: {
-      associate: function (db) {
-        db.user.hasMany(db.task)
-        db.task.belongsTo(db.task)
-      },
-      generateRecovery: function () {
-        this.recoveryToken = uuidv4()
-        this.recoveryTokenExpiration = new Date((new Date()).getTime() + recoveryExpirationMinutes * millisPerMinute)
-      }
-    }
-  })
+  }, {})
+  Model.associate = function (db) {
+    db.user.hasMany(db.task)
+    db.task.belongsTo(db.task)
+  }
+  Model.generateRecovery = function () {
+    this.recoveryToken = uuidv4()
+    this.recoveryTokenExpiration = new Date((new Date()).getTime() + recoveryExpirationMinutes * millisPerMinute)
+  }
+  return Model
 }

--- a/metriq-api/package.json
+++ b/metriq-api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest --runInBand ./coverage",
     "db:schema": "babel-node ./scripts/db/schema",
-    "db:migrate": "babel-node ./scripts/db/migrate"
+    "db:migrate": "babel-node ./scripts/db/migrate",
+    "db:migrate:undo": "npx sequelize-cli db:migrate:undo"
   },
   "keywords": [
     "api",

--- a/metriq-api/service/likeService.js
+++ b/metriq-api/service/likeService.js
@@ -3,10 +3,8 @@
 // Base class
 const SubmissionRefService = require('./submissionRefService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const Like = require('../models/likeModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const Like = db.like
 
 class LikeService extends SubmissionRefService {
   constructor () {

--- a/metriq-api/service/methodService.js
+++ b/metriq-api/service/methodService.js
@@ -3,10 +3,9 @@
 // Data Access Layer
 const ModelService = require('./modelService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const Method = require('../models/methodModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const sequelize = db.sequelize
+const Method = db.method
 
 // Service dependencies
 const SubmissionService = require('./submissionService')

--- a/metriq-api/service/moderationReportService.js
+++ b/metriq-api/service/moderationReportService.js
@@ -4,9 +4,8 @@
 const ModelService = require('./modelService')
 // Database Model
 const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const ModerationReport = require('../models/moderationReportModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const ModerationReport = db.moderationReport
 
 // For email
 const nodemailer = require('nodemailer')

--- a/metriq-api/service/resultService.js
+++ b/metriq-api/service/resultService.js
@@ -3,10 +3,9 @@
 // Data Access Layer
 const ModelService = require('./modelService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const Result = require('../models/resultModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const sequelize = db.sequelize
+const Result = db.result
 
 // Service dependencies
 const SubmissionService = require('../service/submissionService')

--- a/metriq-api/service/submissionMethodRefService.js
+++ b/metriq-api/service/submissionMethodRefService.js
@@ -3,10 +3,8 @@
 // Base class
 const SubmissionRefService = require('./submissionRefService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const SubmissionMethodRef = require('../models/submissionMethodRefModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const SubmissionMethodRef = db.submissionMethodRef
 
 class SubmissionMethodRefService extends SubmissionRefService {
   constructor () {

--- a/metriq-api/service/submissionService.js
+++ b/metriq-api/service/submissionService.js
@@ -1,13 +1,14 @@
 // submissionService.js
 
+const { Op } = require('sequelize')
+
 // Data Access Layer
 const ModelService = require('./modelService')
 // Database Model
 const config = require('../config')
-const { Sequelize, DataTypes, Op } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const Submission = require('../models/submissionModel')(sequelize, DataTypes)
-
+const db = require('../models/index')
+const sequelize = db.sequelize
+const Submission = db.submission
 // For email
 const nodemailer = require('nodemailer')
 

--- a/metriq-api/service/submissionTagRefService.js
+++ b/metriq-api/service/submissionTagRefService.js
@@ -3,10 +3,8 @@
 // Base class
 const SubmissionRefService = require('./submissionRefService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const SubmissionTagRef = require('../models/submissionTagRefModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const SubmissionTagRef = db.submissionTagRef
 
 class SubmissionTagRefService extends SubmissionRefService {
   constructor () {

--- a/metriq-api/service/submissionTaskRefService.js
+++ b/metriq-api/service/submissionTaskRefService.js
@@ -3,10 +3,8 @@
 // Base class
 const SubmissionRefService = require('./submissionRefService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const SubmissionTaskRef = require('../models/submissionTaskRefModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const SubmissionTaskRef = db.submissionTaskRef
 
 class SubmissionTaskRefService extends SubmissionRefService {
   constructor () {

--- a/metriq-api/service/tagService.js
+++ b/metriq-api/service/tagService.js
@@ -3,10 +3,9 @@
 // Data Access Layer
 const ModelService = require('./modelService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const Tag = require('../models/tagModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const sequelize = db.sequelize
+const Tag = db.tag
 
 class TagService extends ModelService {
   constructor () {

--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -3,10 +3,9 @@
 // Data Access Layer
 const ModelService = require('./modelService')
 // Database Model
-const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const Task = require('../models/taskModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const sequelize = db.sequelize
+const Task = db.task
 
 // Service dependencies
 const ResultService = require('./resultService')

--- a/metriq-api/service/userService.js
+++ b/metriq-api/service/userService.js
@@ -6,9 +6,8 @@ const { Op } = require('sequelize')
 const ModelService = require('./modelService')
 // Database Model
 const config = require('../config')
-const { Sequelize, DataTypes } = require('sequelize')
-const sequelize = new Sequelize(config.pgConnectionString)
-const User = require('../models/userModel')(sequelize, DataTypes)
+const db = require('../models/index')
+const User = db.user
 
 // Password hasher
 const bcrypt = require('bcrypt')


### PR DESCRIPTION
Sorry for the false start, right before we published, but this fixes all the model associations after adding migrations tooling, per unitaryfund/metriq-app#414. The model layer code is _much_ cleaner as a result, including a fix for a broken association that was originally present in the code before adding migrations.