### PR TITLE
unitaryfund/metriq-app#411: Top level tasks index

### DIFF
--- a/metriq-api/controller/taskController.js
+++ b/metriq-api/controller/taskController.js
@@ -52,7 +52,7 @@ exports.update = async function (req, res) {
 
 exports.readSubmissionCounts = async function (req, res) {
   routeWrapper(res,
-    async () => await taskService.getAllNamesAndCounts(),
+    async () => await taskService.getTopLevelNamesAndCounts(),
     'Retrieved all task names and counts.')
 }
 

--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -49,11 +49,11 @@ class TaskService extends ModelService {
     return { success: true, body: result }
   }
 
-  async getAllNamesAndCounts () {
+  async getTopLevelNamesAndCounts () {
     const result = (await sequelize.query(
       'SELECT * FROM (' +
       '  SELECT tasks.id as id, tasks.name as name, COUNT(DISTINCT "submissionTaskRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
-      '  RIGHT JOIN tasks on tasks.id = "submissionTaskRefs"."taskId" AND  "submissionTaskRefs"."deletedAt" is NULL ' +
+      '  RIGHT JOIN tasks on tasks.id = "submissionTaskRefs"."taskId" AND tasks."taskId" is NULL AND "submissionTaskRefs"."deletedAt" is NULL ' +
       '  LEFT JOIN submissions on submissions.id = "submissionTaskRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
       '  LEFT JOIN likes on likes."submissionId" = "submissionTaskRefs"."submissionId" ' +
       '  GROUP BY tasks.id' +


### PR DESCRIPTION
Per unitaryfund/metriq-app#411, we now only display top-level tasks in the tasks index. Clicking any of these leads to the task detail view, which lists all children. The remainder of issue 411, if anything remains, if probably to change the existing task hierarchy in the database itself, to head the broadest general task categories.