### PR TITLE
unitaryfund/metriq-app#411: Task/method index views

### DIFF
--- a/metriq-api/controller/methodController.js
+++ b/metriq-api/controller/methodController.js
@@ -59,5 +59,5 @@ exports.readSubmissionCounts = async function (req, res) {
 exports.readNames = async function (req, res) {
   routeWrapper(res,
     async () => await methodService.getAllNames(),
-    'Retrieved all task names.')
+    'Retrieved all method names.')
 }

--- a/metriq-api/service/methodService.js
+++ b/metriq-api/service/methodService.js
@@ -41,7 +41,7 @@ class MethodService extends ModelService {
   async getTopLevelNamesAndCounts () {
     const result = (await sequelize.query(
       'SELECT * FROM (' +
-      '  SELECT methods.id as id, methods.name as name, COUNT(DISTINCT "submissionMethodRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionMethodRefs" ' +
+      '  SELECT methods.id as id, methods.name as name, methods.description as description, COUNT(DISTINCT "submissionMethodRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionMethodRefs" ' +
       '  RIGHT JOIN methods on methods.id = "submissionMethodRefs"."methodId" AND methods."methodId" IS NULL AND "submissionMethodRefs"."deletedAt" IS NULL ' +
       '  LEFT JOIN submissions on submissions.id = "submissionMethodRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
       '  LEFT JOIN likes on likes."submissionId" = "submissionMethodRefs"."submissionId" ' +

--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -52,7 +52,7 @@ class TaskService extends ModelService {
   async getTopLevelNamesAndCounts () {
     const result = (await sequelize.query(
       'SELECT * FROM (' +
-      '  SELECT tasks.id as id, tasks.name as name, COUNT(DISTINCT "submissionTaskRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
+      '  SELECT tasks.id as id, tasks.name as name, tasks.description as description, COUNT(DISTINCT "submissionTaskRefs".*) as "submissionCount", COUNT(DISTINCT likes.*) as "upvoteTotal" from "submissionTaskRefs" ' +
       '  RIGHT JOIN tasks on tasks.id = "submissionTaskRefs"."taskId" AND tasks."taskId" is NULL AND "submissionTaskRefs"."deletedAt" is NULL ' +
       '  LEFT JOIN submissions on submissions.id = "submissionTaskRefs"."submissionId" AND (NOT submissions."approvedAt" IS NULL) AND submissions."deletedAt" IS NULL ' +
       '  LEFT JOIN likes on likes."submissionId" = "submissionTaskRefs"."submissionId" ' +


### PR DESCRIPTION
Continuing with unitaryfund/metriq-app#411, this PR is the back end update for corresponding front end changes:

This applies previously reviewed UI to the task/method index views, and it adds a flattened hierarchy search filter to both views.