### PR TITLE
#505: Results confidence intervals

### DIFF
--- a/metriq-api/migrations/2-363_MethodHierarchy.js
+++ b/metriq-api/migrations/2-363_MethodHierarchy.js
@@ -28,8 +28,8 @@ module.exports = {
   down: (queryInterface, Sequelize) => {
     return queryInterface.sequelize.transaction(t => {
       return Promise.all([
-        queryInterface.removeColumn('tasks', 'isHideChart'),
-        queryInterface.removeColumn('methods', 'methodId')
+        queryInterface.removeColumn('tasks', 'isHideChart', { transaction: t }),
+        queryInterface.removeColumn('methods', 'methodId', { transaction: t })
       ])
     })
   }

--- a/metriq-api/migrations/3-505_ResultsConfidenceIntervals.js
+++ b/metriq-api/migrations/3-505_ResultsConfidenceIntervals.js
@@ -1,0 +1,32 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('results', 'standardError',
+          {
+            type: Sequelize.FLOAT,
+            allowNull: true
+          },
+          { transaction: t }
+        ),
+        queryInterface.addColumn('results', 'sampleSize',
+          {
+            type: Sequelize.INTEGER,
+            allowNull: true
+          },
+          { transaction: t }
+        )
+      ])
+    })
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('results', 'sampleSize', { transaction: t }),
+        queryInterface.removeColumn('results', 'standardError', { transaction: t })
+      ])
+    })
+  }
+}

--- a/metriq-api/models/resultModel.js
+++ b/metriq-api/models/resultModel.js
@@ -22,6 +22,14 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.TEXT,
       allowNull: false,
       defaultValue: ''
+    },
+    standardError: {
+      type: DataTypes.FLOAT,
+      allowNull: true
+    },
+    sampleSize: {
+      type: DataTypes.INTEGER,
+      allowNull: true
     }
   }, {})
   Model.associate = function (db) {

--- a/metriq-api/service/resultService.js
+++ b/metriq-api/service/resultService.js
@@ -87,6 +87,8 @@ class ResultService extends ModelService {
     result.metricValue = reqBody.metricValue
     result.evaluatedAt = reqBody.evaluatedAt
     result.notes = reqBody.notes ? reqBody.notes : ''
+    result.standardError = reqBody.standardError
+    result.sampleSize = reqBody.sampleSize
 
     const nResult = await this.create(result)
     if (!nResult.success) {
@@ -132,6 +134,8 @@ class ResultService extends ModelService {
     result.metricValue = reqBody.metricValue
     result.evaluatedAt = reqBody.evaluatedAt
     result.notes = reqBody.notes ? reqBody.notes : ''
+    result.standardError = reqBody.standardError
+    result.sampleSize = reqBody.sampleSize
 
     result.save()
 


### PR DESCRIPTION
Per issued unitaryfund/metriq-app#505, these are the back end changes to collect optional **standard error** and **sample size** for all **results**.