### PR TITLE
unitaryfund/metriq-app#498: Submission arXiv ID lookup

### DIFF
--- a/metriq-api/api-routes.js
+++ b/metriq-api/api-routes.js
@@ -18,6 +18,7 @@ const tagController = require('./controller/tagController')
 const taskController = require('./controller/taskController')
 const resultController = require('./controller/resultController')
 const methodController = require('./controller/methodController')
+const arxivController = require('./controller/arxivController')
 
 // Register routes.
 router.route('/register')
@@ -105,6 +106,8 @@ router.route('/result/metricNames')
 router.route('/result/:id')
   .post(resultController.update)
   .delete(resultController.delete)
+router.route('/v1/arxiv_id/:id')
+  .get(arxivController.read)
 
 // Export API routes.
 module.exports = router

--- a/metriq-api/controller/arxivController.js
+++ b/metriq-api/controller/arxivController.js
@@ -1,0 +1,44 @@
+// arxivController.js
+
+// Services
+const SubmissionService = require('../service/submissionService')
+const submissionService = new SubmissionService()
+
+function sendResponse (res, code, m) {
+  const body = JSON.stringify({ message: m })
+  res.writeHead(code, {
+    'Content-Length': Buffer.byteLength(body),
+    'Content-Type': 'text/plain'
+  })
+    .end(body)
+}
+
+async function routeWrapper (res, serviceFn, successMessage) {
+  try {
+    // Call the service function, to perform the intended action.
+    const result = await serviceFn()
+    if (result.success) {
+      // If successful, pass the service function result as the API response.
+      res.json({ message: successMessage, data: result.body }).end()
+    } else {
+      // The service function handled an error, but we can't perform the intended action.
+      sendResponse(res, 400, result.error)
+    }
+  } catch (err) {
+    // There was an unhandled exception.
+    sendResponse(res, 500, err)
+  }
+}
+
+exports.read = async function (req, res) {
+  routeWrapper(res,
+    async () => {
+      const submission = await submissionService.getByArxivId(req.params.id)
+      if (submission) {
+        return { success: true, body: submission }
+      } else {
+        return { success: false, error: 'Submission not found with arXiv id.' }
+      }
+    },
+    'Retrieved submission by arXiv ID.')
+}

--- a/metriq-api/controller/arxivController.js
+++ b/metriq-api/controller/arxivController.js
@@ -22,7 +22,7 @@ async function routeWrapper (res, serviceFn, successMessage) {
       res.json({ message: successMessage, data: result.body }).end()
     } else {
       // The service function handled an error, but we can't perform the intended action.
-      sendResponse(res, 400, result.error)
+      sendResponse(res, 404, result.error)
     }
   } catch (err) {
     // There was an unhandled exception.

--- a/metriq-api/index.js
+++ b/metriq-api/index.js
@@ -21,7 +21,7 @@ app.use(cors())
 
 // Import routes.
 const apiRoutes = require('./api-routes')
-const publicApiRoutes = ['/api/login', '/api/register', '/api/recover', '/api/password', '/api/tag']
+const publicApiRoutes = ['/api/login', '/api/register', '/api/recover', '/api/password', '/api/tag', '/api/v1/arxiv_id']
 const unless = function (paths, middleware) {
   return function (req, res, next) {
     if ((req.method === 'GET') &&

--- a/metriq-api/service/submissionService.js
+++ b/metriq-api/service/submissionService.js
@@ -127,6 +127,11 @@ class SubmissionService extends ModelService {
     return { success: true, body: result }
   }
 
+  async getByArxivId (arxivId) {
+    const url = 'https://arxiv.org/abs/' + arxivId
+    return await this.SequelizeServiceInstance.findOne({ contentUrl: url })
+  }
+
   async get (submissionNameOrId) {
     const submission = await this.getByNameOrId(submissionNameOrId)
     return { success: true, body: submission }


### PR DESCRIPTION
This addresses issue unitaryfund/metriq-app#498. Querying the route with a given arXiv ID, the Metriq submission row is returned if found, (including Metriq submission ID). Otherwise, the route returns `HTTP 404 NOT FOUND`.