### PR TITLE
unitaryfund/metriq-app#523: Top level categories optgroup

### DIFF
--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -51,7 +51,7 @@ class TaskService extends ModelService {
   }
 
   async getAllNames () {
-    const result = await this.SequelizeServiceInstance.projectAll(['id', 'name'])
+    const result = await this.SequelizeServiceInstance.projectAll(['id', 'name', [sequelize.literal('CASE WHEN "taskId" IS NULL THEN 1 ELSE 0 END'), 'top']])
     return { success: true, body: result }
   }
 


### PR DESCRIPTION
Per https://github.com/unitaryfund/metriq-app/issues/523, this makes top level categories a visually distinct <optgroup> among tasks.