### PR TITLE
unitaryfund/metriq-app#577: Block task/method/platform deletion, if keyed

### DIFF
--- a/metriq-api/service/methodService.js
+++ b/metriq-api/service/methodService.js
@@ -12,6 +12,8 @@ const SubmissionService = require('./submissionService')
 const submissionService = new SubmissionService()
 const SubmissionMethodRefService = require('./submissionMethodRefService')
 const submissionMethodRefService = new SubmissionMethodRefService()
+const ResultService = require('./resultService')
+const resultService = new ResultService()
 
 class MethodService extends ModelService {
   constructor () {
@@ -213,6 +215,10 @@ class MethodService extends ModelService {
     } else {
       const ref = await submissionMethodRefService.getByFks(submission.id, method.id)
       if (ref) {
+        const results = (await resultService.getByMethodIdAndSubmissionId(method.id, submission.id)).body
+        if (results && results.length) {
+          return { success: false, error: 'Cannot delete submission method reference with result. Change or delete results in the submission that use this method, first.' }
+        }
         await submissionMethodRefService.deleteByPk(ref.id)
       }
     }

--- a/metriq-api/service/platformService.js
+++ b/metriq-api/service/platformService.js
@@ -13,6 +13,8 @@ const SubmissionService = require('./submissionService')
 const submissionService = new SubmissionService()
 const SubmissionPlatformRefService = require('./submissionPlatformRefService')
 const submissionPlatformRefService = new SubmissionPlatformRefService()
+const ResultService = require('./resultService')
+const resultService = new ResultService()
 
 class PlatformService extends ModelService {
   constructor () {
@@ -251,6 +253,10 @@ class PlatformService extends ModelService {
     } else {
       const ref = await submissionPlatformRefService.getByFks(submission.id, platform.id)
       if (ref) {
+        const results = (await resultService.getByPlatformIdSubmissionId(platform.id, submission.id)).body
+        if (results && results.length) {
+          return { success: false, error: 'Cannot delete submission platform reference with result. Change or delete results in the submission that use this platform, first.' }
+        }
         await submissionPlatformRefService.deleteByPk(ref.id)
       }
     }

--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -276,6 +276,10 @@ class TaskService extends ModelService {
     } else {
       const ref = await submissionTaskRefService.getByFks(submission.id, task.id)
       if (ref) {
+        const results = (await resultService.getByTaskIdAndSubmissionId(task.id, submission.id)).body
+        if (results && results.length) {
+          return { success: false, error: 'Cannot delete submission task reference with result. Change or delete results in the submission that use this task, first.' }
+        }
         await submissionTaskRefService.deleteByPk(ref.id)
       }
     }


### PR DESCRIPTION
Per unitaryfund/metriq-app#577, this prevents the deletion of submission references to tasks/methods/platforms, when these references are also actively referenced by a result in that submission.