### PR TITLE
#677: Twitter handle

### DIFF
--- a/metriq-api/migrations/10-677_UserTwitterHandles.js
+++ b/metriq-api/migrations/10-677_UserTwitterHandles.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('users', 'twitterHandle', {
+      type: Sequelize.DataTypes.TEXT,
+      defaultValue: '',
+      allowNull: false
+    })
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn('users', 'twitterHandle')
+  }
+}

--- a/metriq-api/models/userModel.js
+++ b/metriq-api/models/userModel.js
@@ -50,6 +50,11 @@ module.exports = function (sequelize, DataTypes) {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false
+    },
+    twitterHandle: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      defaultValue: ''
     }
   }, {})
   Model.associate = function (db) {

--- a/metriq-api/service/submissionService.js
+++ b/metriq-api/service/submissionService.js
@@ -157,8 +157,8 @@ class SubmissionService extends ModelService {
     }
   }
 
-  async tweet (submission) {
-    let title = 'New submission: ' + submission.name
+  async tweet (submission, twitterHandle) {
+    let title = 'New submission' + (twitterHandle ? ' by ' + twitterHandle + ': ' :  ': ') + submission.name
     const link = '\nhttps://metriq.info/Submission/' + submission.id.toString()
     const tweetLength = (title + link).length
     if (tweetLength > 260) {
@@ -271,7 +271,7 @@ class SubmissionService extends ModelService {
     }
 
     if (reqBody.isPublished && config.twitter.accessSecret) {
-      await this.tweet(submission)
+      await this.tweet(submission, user.twitterHandle)
 
       const emailResult = await transporter.sendMail(mailOptions)
       if (!emailResult.accepted || (emailResult.accepted[0] !== user.email)) {
@@ -347,7 +347,8 @@ class SubmissionService extends ModelService {
     submission = await submissionSqlService.populate(submission, userId)
 
     if (doTweet && config.twitter.accessSecret) {
-      await this.tweet(submission)
+      const user = await userService.getByPk(userId)
+      await this.tweet(submission, user ? user.twitterHandle : '')
     }
 
     return { success: true, body: submission }

--- a/metriq-api/service/userService.js
+++ b/metriq-api/service/userService.js
@@ -37,7 +37,8 @@ class UserService extends ModelService {
       affiliation: user.affiliation,
       name: user.name,
       createdAt: user.createdAt,
-      isSubscribedToNewSubmissions: user.isSubscribedToNewSubmissions
+      isSubscribedToNewSubmissions: user.isSubscribedToNewSubmissions,
+      twitterHandle: user.twitterHandle
     }
   }
 
@@ -284,14 +285,17 @@ class UserService extends ModelService {
       return { success: false, error: 'User not found.' }
     }
 
-    if (reqBody.name) {
+    if (reqBody.name !== undefined) {
       user.name = reqBody.name
     }
-    if (reqBody.email) {
+    if (reqBody.email !== undefined) {
       user.email = reqBody.email
     }
-    if (reqBody.affiliation) {
+    if (reqBody.affiliation !== undefined) {
       user.affiliation = reqBody.affiliation
+    }
+    if (reqBody.twitterHandle !== undefined) {
+      user.twitterHandle = reqBody.twitterHandle
     }
 
     await user.save()

--- a/metriq-api/service/userService.js
+++ b/metriq-api/service/userService.js
@@ -106,6 +106,7 @@ class UserService extends ModelService {
     user.name = reqBody.name ? reqBody.name : ''
     user.email = reqBody.email.trim().toLowerCase()
     user.passwordHash = await bcrypt.hash(reqBody.password, saltRounds)
+    user.isSubscribedToNewSubmissions = false;
 
     const result = await this.create(user)
     if (!result.success) {

--- a/metriq-api/service/userService.js
+++ b/metriq-api/service/userService.js
@@ -102,6 +102,7 @@ class UserService extends ModelService {
     user.username = reqBody.username.trim()
     user.usernameNormal = reqBody.username.trim().toLowerCase()
     user.affiliation = reqBody.affiliation ? reqBody.affiliation : ''
+    user.twitterHandle = reqBody.twitterHandle ? reqBody.twitterHandle : ''
     user.name = reqBody.name ? reqBody.name : ''
     user.email = reqBody.email.trim().toLowerCase()
     user.passwordHash = await bcrypt.hash(reqBody.password, saltRounds)
@@ -138,6 +139,12 @@ class UserService extends ModelService {
 
   validatePassword (password) {
     return password && (password.length >= 12)
+  }
+
+  validateTwitterHandle (handle) {
+    // https://codepen.io/SitePoint/pen/yLbqeg
+    const re = /^@[A-Za-z0-9_]{1,15}$/
+    return re.test(handle)
   }
 
   async validateRegistration (reqBody) {
@@ -180,6 +187,10 @@ class UserService extends ModelService {
     const emailMatch = await this.getByEmail(tlEmail)
     if (emailMatch) {
       return { success: false, error: 'Email already in use.' }
+    }
+
+    if (reqBody.twitterHandle && !this.validateTwitterHandle(reqBody.twitterHandle)) {
+      return { success: false, error: 'Invalid Twitter handle format.' }
     }
 
     return { success: true }


### PR DESCRIPTION
This addresses #677. Twitter handles are optionally collected for member profiles. If the user provides their Twitter handle, then the MetriqInfo bot tweets at them, whenever the bot tweets one of the member's submissions.