### PR TITLE
unitaryfund/metriq-app#765: Back end for qubit width and depth result metadata

### DIFF
--- a/metriq-api/migrations/11-765_ResultMetadata.js
+++ b/metriq-api/migrations/11-765_ResultMetadata.js
@@ -1,0 +1,29 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('results', 'qubitCount',
+          {
+            type: Sequelize.INTEGER,
+            allowNull: true
+          }, { transaction: t }),
+        queryInterface.addColumn('results', 'circuitDepth',
+          {
+            type: Sequelize.INTEGER,
+            allowNull: true
+          }, { transaction: t })
+      ])
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('results', 'circuitDepth'),
+        queryInterface.removeColumn('results', 'qubitCount')
+      ])
+    })
+  }
+}

--- a/metriq-api/models/resultModel.js
+++ b/metriq-api/models/resultModel.js
@@ -30,6 +30,14 @@ module.exports = function (sequelize, DataTypes) {
     sampleSize: {
       type: DataTypes.INTEGER,
       allowNull: true
+    },
+    qubitCount: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
+    circuitDepth: {
+      type: DataTypes.INTEGER,
+      allowNull: true
     }
   }, {})
   Model.associate = function (db) {

--- a/metriq-api/service/resultService.js
+++ b/metriq-api/service/resultService.js
@@ -163,6 +163,8 @@ class ResultService extends ModelService {
     result.notes = reqBody.notes ? reqBody.notes : ''
     result.standardError = reqBody.standardError
     result.sampleSize = reqBody.sampleSize
+    result.qubitCount = reqBody.qubitCount
+    result.circuitDepth = reqBody.circuitDepth
 
     const nResult = await this.create(result)
     if (!nResult.success) {
@@ -218,6 +220,8 @@ class ResultService extends ModelService {
     result.notes = reqBody.notes ? reqBody.notes : ''
     result.standardError = reqBody.standardError
     result.sampleSize = reqBody.sampleSize
+    result.qubitCount = reqBody.qubitCount
+    result.circuitDepth = reqBody.circuitDepth
 
     result.save()
 


### PR DESCRIPTION
(Back end for unitaryfund/metriq-app#765)