### PR TITLE
Initial pass at getting benchmark data for QFT.

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -26,5 +26,20 @@ Once the `poetry` shell has been invoked, one may run the `run.py` script as
 python run.py
 ```
 
-Doing so will iterate over the lists of `algorithms` and `providers` for the
-benchmarks that are to be run.
+In order to select which benchmarks to run, we can specify this in the `benchmarks` dictionary:
+
+```json
+    "<INTEGER>" : {
+        "algorithm": "<NAME_OF_ALGORITHM>",
+        "providers": [
+            {"<NAME_OF_PROVIDER>": "<NAME_OF_DEVICE>"}
+        ]
+    }
+```
+
+where:
+- `<INTEGER>` is some unique integer,
+- `<NAME_OF_ALGORITHM>` is one of the folder names pertaining to an algorithm inside of `benchmark/QC-App-Oriented-Benchmarks/`
+- `<NAME_OF_PROVIDER>` is either `qiskit`, `cirq`, or `braket` (depending on which providers are supported)
+- `<NAME_OF_DEVICE>` is the name of the device to run on. By default, this is a simulator, but one can specify hardware connection strings here.
+

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,27 +1,58 @@
+"""Run QED-C benchmarks."""
+import ast
 import os
 import subprocess
 from git import Repo
 
+
 # Specify path of QED-C repo and where to check it out:
 project_name = "benchmark"
 repo_name = "QC-App-Oriented-Benchmarks"
-git_url = "https://github.com/SRI-International/QC-App-Oriented-Benchmarks"
+git_url = "https://github.com/unitaryfund/QC-App-Oriented-Benchmarks"
 repo_dir = os.path.join(project_name, repo_name)
 
-# Clone QED-C repo:
-print(f"Cloining {git_url} into {repo_dir}...")
-Repo.clone_from(git_url, repo_dir)
-print("Clone complete")
+# If QED-C repo does not exist locally, clone it:
+if os.path.exists(repo_dir):
+    print(f"QED-C benchmarks repository present in {repo_dir}")
+else:
+    print(f"Cloining {git_url} into {repo_dir}...")
+    Repo.clone_from(git_url, repo_dir)
+    print("Clone complete")
 
 # To run this locally, we'll need to change directories:
 dir_path = os.path.dirname(os.path.realpath(__file__))
 os.chdir(os.path.join(dir_path, project_name, repo_name))
 
 # Run the specified algorithms over the list of provider offerings:
-algorithms = ["grovers"]
-proviers = ["cirq", "qiskit", "braket"]
-for algorithm in algorithms:
-    for provider in proviers:
-        print(f"Running algorithm {algorithm} with Python module provider {provider}...")
-        benchmark_script = [f for f in os.listdir(os.path.join(algorithm, provider)) if f.endswith('_benchmark.py')][0]
-        subprocess.run(["python", f"{os.path.join(algorithm, provider, benchmark_script)}"])
+benchmarks = {
+    "1" : {
+        "algorithm": "quantum-fourier-transform",
+        "providers": [
+            {"qiskit": "qasm_simulator"}
+        ]
+    }
+}
+
+# Process each benchmark:
+for benchmark in benchmarks:
+    algorithm = benchmarks[benchmark]["algorithm"]
+    print(f"Running benchmark for {algorithm}...")
+
+    providers = benchmarks[benchmark]["providers"]
+    for provider in providers:
+        for environment, device in provider.items():
+            benchmark_script = [f for f in os.listdir(os.path.join(algorithm, environment)) if f.endswith('_benchmark.py')][0]
+
+            # Run each benchmark script with command line args:
+            result = subprocess.run(
+                ["python", f"{os.path.join(algorithm, environment, benchmark_script)}", "-backend_id", f"{device}"],
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+
+            # Data obtained is a string, so interpret as dictionary and store in benchmarking dictionary.
+            data = ast.literal_eval(result.stdout.decode("utf8").split("\n")[-2])
+            print(data)
+
+            # TODO: At this point, we would have some Metriq API call that would
+            # take the data object and insert it into the QED-C submission on
+            # Metriq.


### PR DESCRIPTION
@WrathfulSpatula here is a first pass at getting the benchmarks to run for QFT.

First, since extracting data from QED-C requires some modifications to their benchmarking script, I forked their repo and made some changes (just to QFT for now). This is the repo that our `run.py` script pulls down now.

One can now specify which benchmarks to run in a Python dict/JSON object. The data is captured and (at present) printed out, although in the future, we'll want to send this to the Metriq client.

For instance, the present benchmark script works with the `benchmarks` dict formatted as follows:

```python
benchmarks = {
    "1" : {
        "algorithm": "quantum-fourier-transform",
        "providers": [
            {"qiskit": "qasm_simulator"}
        ]
    }
}
```

However, that still runs on a sim. We can pass in another argument here to force it to run on IBM hardware:

```python
benchmarks = {
    "1" : {
        "algorithm": "quantum-fourier-transform",
        "providers": [
            {"qiskit": "ibmq_lima"}
        ]
    }
}
```

where now, the execution of the benchmark will take quite a bit more time. 

Generally speaking, we can make similar modifications to the other algorithm files and follow this rubric going forward. 

Any thoughts @WrathfulSpatula ?