### PR TITLE
unitaryfund/metriq-app#781: Accept Twitter handles with or without '@…

### DIFF
--- a/metriq-api/service/userService.js
+++ b/metriq-api/service/userService.js
@@ -145,7 +145,7 @@ class UserService extends ModelService {
 
   validateTwitterHandle (handle) {
     // https://codepen.io/SitePoint/pen/yLbqeg
-    const re = /^@[A-Za-z0-9_]{1,15}$/
+    const re = /^@?[A-Za-z0-9_]{1,15}$/
     return re.test(handle)
   }
 


### PR DESCRIPTION
Per issue unitaryfund/metriq-app#781, after a user had an issue with signup, the Twitter handle field now accepts inputs with and without a leading `@` character.