### PR TITLE
Adding more functionality to benchmarking.

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,8 +23,10 @@ poetry shell
 Once the `poetry` shell has been invoked, one may run the `run.py` script as
 
 ```
-python run.py
+python run.py -token <TOKEN>
 ```
+
+where `<TOKEN>` is the Metriq API token obtained from your Metriq account.
 
 In order to select which benchmarks to run, we can specify this in the `benchmarks` dictionary:
 

--- a/benchmark/metadata.py
+++ b/benchmark/metadata.py
@@ -1,0 +1,91 @@
+# Map of QED-C algorithm names to Metriq task names and ids:
+metriq_task_name_map = {
+    "amplitude-estimate": {
+        "name": "Amplitude estimation",
+        "task_id": "176",
+    },
+    "bernstein-vazirani": {
+        "name": "Bernstein-Vazirani",
+        "task_id": "150",
+    },
+    "vqe": {
+        "name": "VQE",
+        "task_id": "179",
+    },
+    "hamiltonian-simulation": {
+        "name": "Hamiltonian Simulation",
+        "task_id": "178",
+    },
+    "monte-carlo": {
+        "name": "Monte Carlo sampling",
+        "task_id": "177",
+    },
+    "shors": {
+        "name": "Shor's order-finding",
+        "task_id": "175",
+    },
+    "phase-estimation": {
+        "name": "Phase estimation",
+        "task_id": "174",
+    },
+    "hidden-shift": {
+        "name": "Hidden shift",
+        "task_id": "173",
+    },
+    "deutsch-jozsa": {
+        "name": "Deutsch-Josza",
+        "task_id": "172",
+    },
+    "quantum-fourier-transform": {
+        "name": "Quantum Fourier transform",
+        "task_id": "142",
+    },
+    "grovers": {
+        "name": "Grover's Search",
+        "task_id": "97",
+    },
+}
+
+# Map of QED-C device names to Metriq platform names and ids:
+metriq_platform_name_map = {
+    "ibmq_belem": {
+        "name": "ibmq-belem",
+        "platform_id": "26",
+    },
+    "ibmq_bogota": {
+        "name": "ibmq-bogota",
+        "platform_id": "2",
+    },
+    "ibmq_casablanca": {
+        "name": "ibmq-casablanca",
+        "platform_id": "21",
+    },
+    "ibmq_guadalupe": {
+        "name": "ibmq-guadalupe",
+        "platform_id": "19",
+    },
+    "ibmq_perth": {
+        "name": "ibmq-perth",
+        "platform_id": "22",
+    },
+    "qasm_simulator": {
+        "name": "qasm-simulator",
+        "platform_id": "",
+    },
+}
+
+# Benchmarks to run:
+benchmarks = {
+    "1" : {
+        "algorithm": "quantum-fourier-transform",
+        "min_qubits": 2,
+        "max_qubits": 8,
+        "num_shots": 100,
+        "providers": [
+            {"qiskit": "qasm_simulator"},
+            #{"qiskit": "ibmq_belem"},
+            #{"cirq": "qasm_simulator"},
+            #{"braket": "qasm_simulator"},
+        ]
+    }
+}

--- a/benchmark/poetry.lock
+++ b/benchmark/poetry.lock
@@ -104,21 +104,21 @@ trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
 name = "attrs"
-version = "20.3.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
-    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
-    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "furo", "hypothesis", "pre-commit", "pympler", "pytest (>=4.3.0)", "six", "sphinx", "zope.interface"]
-docs = ["furo", "sphinx", "zope.interface"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
-tests-no-zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "backoff"
@@ -146,18 +146,18 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.26.55"
+version = "1.26.64"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "boto3-1.26.55-py3-none-any.whl", hash = "sha256:e8ae1567b0a21d410f9c8a16a17a8028445a52061482272b4a516f5de5abbd92"},
-    {file = "boto3-1.26.55.tar.gz", hash = "sha256:d68576dcb1c520474eafb64b996661068a369f40bbd104ccb9502cad71849e57"},
+    {file = "boto3-1.26.64-py3-none-any.whl", hash = "sha256:777b00e17eddeb92cf5d4674d61453d9bbaeb5bfde4485cb55995bfd07aeefce"},
+    {file = "boto3-1.26.64.tar.gz", hash = "sha256:b0e3d078ec56bc858cc5edae4cda3eed2b1872055828cf5f22d83fc6f79a6d40"},
 ]
 
 [package.dependencies]
-botocore = ">=1.29.55,<1.30.0"
+botocore = ">=1.29.64,<1.30.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -166,14 +166,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.29.55"
+version = "1.29.64"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 files = [
-    {file = "botocore-1.29.55-py3-none-any.whl", hash = "sha256:dd8a0868b287015bed086c97b866f9bb8ca57737d15972d3ac773559f4088db8"},
-    {file = "botocore-1.29.55.tar.gz", hash = "sha256:5fe6b8809292bb178a9378fea4f96bc969003d1048cf6de8ad3c5a73690fefa9"},
+    {file = "botocore-1.29.64-py3-none-any.whl", hash = "sha256:a1e06b8d6cb65bb8bade392bbc8d11f4431a1658f61c1ff7db5008ac20558862"},
+    {file = "botocore-1.29.64.tar.gz", hash = "sha256:2424c96547eeb9b76eb5bcee5b5bc01741834f525ecc4d538d71d269c7ba6662"},
 ]
 
 [package.dependencies]
@@ -182,7 +182,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<1.27"
 
 [package.extras]
-crt = ["awscrt (==0.15.3)"]
+crt = ["awscrt (==0.16.9)"]
 
 [[package]]
 name = "cachetools"
@@ -834,61 +834,61 @@ grpc = ["grpcio (>=1.44.0,<2.0.0dev)"]
 
 [[package]]
 name = "grpcio"
-version = "1.51.1"
+version = "1.52.0"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "grpcio-1.51.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:cc2bece1737b44d878cc1510ea04469a8073dbbcdd762175168937ae4742dfb3"},
-    {file = "grpcio-1.51.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:e223a9793522680beae44671b9ed8f6d25bbe5ddf8887e66aebad5e0686049ef"},
-    {file = "grpcio-1.51.1-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:24ac1154c4b2ab4a0c5326a76161547e70664cd2c39ba75f00fc8a2170964ea2"},
-    {file = "grpcio-1.51.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4ef09f8997c4be5f3504cefa6b5c6cc3cf648274ce3cede84d4342a35d76db6"},
-    {file = "grpcio-1.51.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0b77e992c64880e6efbe0086fe54dfc0bbd56f72a92d9e48264dcd2a3db98"},
-    {file = "grpcio-1.51.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:eacad297ea60c72dd280d3353d93fb1dcca952ec11de6bb3c49d12a572ba31dd"},
-    {file = "grpcio-1.51.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:16c71740640ba3a882f50b01bf58154681d44b51f09a5728180a8fdc66c67bd5"},
-    {file = "grpcio-1.51.1-cp310-cp310-win32.whl", hash = "sha256:29cb97d41a4ead83b7bcad23bdb25bdd170b1e2cba16db6d3acbb090bc2de43c"},
-    {file = "grpcio-1.51.1-cp310-cp310-win_amd64.whl", hash = "sha256:9ff42c5620b4e4530609e11afefa4a62ca91fa0abb045a8957e509ef84e54d30"},
-    {file = "grpcio-1.51.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:bc59f7ba87972ab236f8669d8ca7400f02a0eadf273ca00e02af64d588046f02"},
-    {file = "grpcio-1.51.1-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:3c2b3842dcf870912da31a503454a33a697392f60c5e2697c91d133130c2c85d"},
-    {file = "grpcio-1.51.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22b011674090594f1f3245960ced7386f6af35485a38901f8afee8ad01541dbd"},
-    {file = "grpcio-1.51.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49d680356a975d9c66a678eb2dde192d5dc427a7994fb977363634e781614f7c"},
-    {file = "grpcio-1.51.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:094e64236253590d9d4075665c77b329d707b6fca864dd62b144255e199b4f87"},
-    {file = "grpcio-1.51.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:257478300735ce3c98d65a930bbda3db172bd4e00968ba743e6a1154ea6edf10"},
-    {file = "grpcio-1.51.1-cp311-cp311-win32.whl", hash = "sha256:5a6ebcdef0ef12005d56d38be30f5156d1cb3373b52e96f147f4a24b0ddb3a9d"},
-    {file = "grpcio-1.51.1-cp311-cp311-win_amd64.whl", hash = "sha256:3f9b0023c2c92bebd1be72cdfca23004ea748be1813a66d684d49d67d836adde"},
-    {file = "grpcio-1.51.1-cp37-cp37m-linux_armv7l.whl", hash = "sha256:cd3baccea2bc5c38aeb14e5b00167bd4e2373a373a5e4d8d850bd193edad150c"},
-    {file = "grpcio-1.51.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:17ec9b13cec4a286b9e606b48191e560ca2f3bbdf3986f91e480a95d1582e1a7"},
-    {file = "grpcio-1.51.1-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:fbdbe9a849854fe484c00823f45b7baab159bdd4a46075302281998cb8719df5"},
-    {file = "grpcio-1.51.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:31bb6bc7ff145e2771c9baf612f4b9ebbc9605ccdc5f3ff3d5553de7fc0e0d79"},
-    {file = "grpcio-1.51.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e473525c28251558337b5c1ad3fa969511e42304524a4e404065e165b084c9e4"},
-    {file = "grpcio-1.51.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6f0b89967ee11f2b654c23b27086d88ad7bf08c0b3c2a280362f28c3698b2896"},
-    {file = "grpcio-1.51.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7942b32a291421460d6a07883033e392167d30724aa84987e6956cd15f1a21b9"},
-    {file = "grpcio-1.51.1-cp37-cp37m-win32.whl", hash = "sha256:f96ace1540223f26fbe7c4ebbf8a98e3929a6aa0290c8033d12526847b291c0f"},
-    {file = "grpcio-1.51.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f1fec3abaf274cdb85bf3878167cfde5ad4a4d97c68421afda95174de85ba813"},
-    {file = "grpcio-1.51.1-cp38-cp38-linux_armv7l.whl", hash = "sha256:0e1a9e1b4a23808f1132aa35f968cd8e659f60af3ffd6fb00bcf9a65e7db279f"},
-    {file = "grpcio-1.51.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:6df3b63538c362312bc5fa95fb965069c65c3ea91d7ce78ad9c47cab57226f54"},
-    {file = "grpcio-1.51.1-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:172405ca6bdfedd6054c74c62085946e45ad4d9cec9f3c42b4c9a02546c4c7e9"},
-    {file = "grpcio-1.51.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:506b9b7a4cede87d7219bfb31014d7b471cfc77157da9e820a737ec1ea4b0663"},
-    {file = "grpcio-1.51.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fb93051331acbb75b49a2a0fd9239c6ba9528f6bdc1dd400ad1cb66cf864292"},
-    {file = "grpcio-1.51.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5dca372268c6ab6372d37d6b9f9343e7e5b4bc09779f819f9470cd88b2ece3c3"},
-    {file = "grpcio-1.51.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:471d39d3370ca923a316d49c8aac66356cea708a11e647e3bdc3d0b5de4f0a40"},
-    {file = "grpcio-1.51.1-cp38-cp38-win32.whl", hash = "sha256:75e29a90dc319f0ad4d87ba6d20083615a00d8276b51512e04ad7452b5c23b04"},
-    {file = "grpcio-1.51.1-cp38-cp38-win_amd64.whl", hash = "sha256:f1158bccbb919da42544a4d3af5d9296a3358539ffa01018307337365a9a0c64"},
-    {file = "grpcio-1.51.1-cp39-cp39-linux_armv7l.whl", hash = "sha256:59dffade859f157bcc55243714d57b286da6ae16469bf1ac0614d281b5f49b67"},
-    {file = "grpcio-1.51.1-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:dad6533411d033b77f5369eafe87af8583178efd4039c41d7515d3336c53b4f1"},
-    {file = "grpcio-1.51.1-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:4c4423ea38a7825b8fed8934d6d9aeebdf646c97e3c608c3b0bcf23616f33877"},
-    {file = "grpcio-1.51.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0dc5354e38e5adf2498312f7241b14c7ce3484eefa0082db4297189dcbe272e6"},
-    {file = "grpcio-1.51.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97d67983189e2e45550eac194d6234fc38b8c3b5396c153821f2d906ed46e0ce"},
-    {file = "grpcio-1.51.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:538d981818e49b6ed1e9c8d5e5adf29f71c4e334e7d459bf47e9b7abb3c30e09"},
-    {file = "grpcio-1.51.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9235dcd5144a83f9ca6f431bd0eccc46b90e2c22fe27b7f7d77cabb2fb515595"},
-    {file = "grpcio-1.51.1-cp39-cp39-win32.whl", hash = "sha256:aacb54f7789ede5cbf1d007637f792d3e87f1c9841f57dd51abf89337d1b8472"},
-    {file = "grpcio-1.51.1-cp39-cp39-win_amd64.whl", hash = "sha256:2b170eaf51518275c9b6b22ccb59450537c5a8555326fd96ff7391b5dd75303c"},
-    {file = "grpcio-1.51.1.tar.gz", hash = "sha256:e6dfc2b6567b1c261739b43d9c59d201c1b89e017afd9e684d85aa7a186c9f7a"},
+    {file = "grpcio-1.52.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:7a6f6e2857908f9d7dc9a3150d45c72a35c351aa74621100145bd8ce4d083cac"},
+    {file = "grpcio-1.52.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:b0c55958d3aa9b60eabd1cb230e2d80e48bc4baa2f7e90e7637dc8429538599a"},
+    {file = "grpcio-1.52.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:ef46f86aabc254d1599adf00eaa47f9d8b8c2af51b89934f0dbe2309b829c778"},
+    {file = "grpcio-1.52.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5d767848c6540130b00255d062e0eee7e8fe53dabef6c7bdf19b8e12085324f7"},
+    {file = "grpcio-1.52.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c07775ad29baaa957e13a2fdb9724aa734b81be9be015c25d36bd93544a9279e"},
+    {file = "grpcio-1.52.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8e64e5d2e76745584c193e29f68fa038ad516e3b03fb16ccff9cc6c416c08b94"},
+    {file = "grpcio-1.52.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bc9467256c0525f83cadf0a77141ea393d3ed1bd1c218ac835e073d8a56d3c50"},
+    {file = "grpcio-1.52.0-cp310-cp310-win32.whl", hash = "sha256:7d4da24ec79183a27e690de06e7b5765734fe958651473b27c7d0020a2e465e4"},
+    {file = "grpcio-1.52.0-cp310-cp310-win_amd64.whl", hash = "sha256:b274c8240b30cccca70128051e767b498679040f29304b904e463249c06f37ab"},
+    {file = "grpcio-1.52.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:9cb42152c9880d340fc879ef86c9362014d029c1aac5629b1ff6b013e7722965"},
+    {file = "grpcio-1.52.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:fefbf58dd05b6aaf39dfe1df4a1464680b44496cc617083cb141ec18aac1d6d4"},
+    {file = "grpcio-1.52.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ed59aeb98cd95ba794d6fc77623f4bb340d1a362c0e156c086e942d21403d2a"},
+    {file = "grpcio-1.52.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c5553e5d881a733512cca25f810d746d7f405dcaddf0525bf99c8e7953c4ecd"},
+    {file = "grpcio-1.52.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:24fdf136bc0ccf85a3c0a572c3ea71957529299d4ec208eb1f2a1d06f2b17cf2"},
+    {file = "grpcio-1.52.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bc7976baed22b87548bfd37defddb4344f4a9959bf3d276ae2cb624caa11c234"},
+    {file = "grpcio-1.52.0-cp311-cp311-win32.whl", hash = "sha256:84edd2ae3c0e4ca320dfc79c24ea554e06faf1a21e5ebdb1441450dec702444e"},
+    {file = "grpcio-1.52.0-cp311-cp311-win_amd64.whl", hash = "sha256:ae38c4f5e724fe85550714d56213a2eb4335a1a795bff88b3dbc75cfbc036ef2"},
+    {file = "grpcio-1.52.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:10ac3d9cbc576642257c5bc674b3f6349ebcfd0ce198630423c4dedae4e545ec"},
+    {file = "grpcio-1.52.0-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:e61683fd0a8a05ba788a067942c2bc73368cbf7836f0071268fc0abadc287dea"},
+    {file = "grpcio-1.52.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:f290c80604a0fd0e202b4f76f3bc6eed6c0750e88525f91219ccb5cc99213fca"},
+    {file = "grpcio-1.52.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7bb4cae47cf9fe2bd51ddabb14f310dc35812c3676c8972006119a8b01050567"},
+    {file = "grpcio-1.52.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25175ed51891150e16bc63b69fb96db71b04080a17c09e83f750e118fa5b775a"},
+    {file = "grpcio-1.52.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:d9e06472f59f585235ac51e4645f42a02a262fc7480fad13ede0b3c11cefa8a1"},
+    {file = "grpcio-1.52.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:c073f4fdcbdac14fbb1b9c001222c76c446874a8ec6def028e72a746cc9cc20e"},
+    {file = "grpcio-1.52.0-cp37-cp37m-win32.whl", hash = "sha256:acf13fabfb5d974e5c489c6fabe3037a6d8105030e9571cf7f8f6f92c49e734c"},
+    {file = "grpcio-1.52.0-cp37-cp37m-win_amd64.whl", hash = "sha256:53406f1384406a66c18a9034265d0ad7eeafd3579da552c459bfa330ef43fcf8"},
+    {file = "grpcio-1.52.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:b49126b66bde56d90d970e9d091e26b600d345a8222f4214f732b30cf63756d9"},
+    {file = "grpcio-1.52.0-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:9b929fb9ee7ae082c7930aa58128138ab26f1c60e205b541f0a18975a74c2641"},
+    {file = "grpcio-1.52.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:434a693418dd706f6ba27d9b5ee5a6c7ee0302b197ac3e05e4080501a31b0b73"},
+    {file = "grpcio-1.52.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d05eef8a94d74459582cd36dbc34aa6f2e0dcb4d59f08c8093b9728f0ccf694a"},
+    {file = "grpcio-1.52.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6354bc9083a57b1c6e0cc87065733c356806fa8260ec055387a73d445cf5a1d6"},
+    {file = "grpcio-1.52.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:f34376ef75d7f70ad2c07fc7750a3293c034cce09aafc82fe7ae782542cce687"},
+    {file = "grpcio-1.52.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2f86596763fe0c2077c7193c9d941d282b4bd7c086262e797e8d4290a3cfa9d5"},
+    {file = "grpcio-1.52.0-cp38-cp38-win32.whl", hash = "sha256:d37b32f043f7f1a0d6512cabb0439e987a2c7f946e97c87fa4e26e46dfce8ef0"},
+    {file = "grpcio-1.52.0-cp38-cp38-win_amd64.whl", hash = "sha256:92602fc9457f2957a9505a2e8d53e8382345494b32b551626723c4ead304c539"},
+    {file = "grpcio-1.52.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:486632391067cfa9acd0d58d76543fe26449d8d647ab5f24b24879f4fa45846b"},
+    {file = "grpcio-1.52.0-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:c73cfc5ef2193b2ab215576524e915bf38ed96b3557086e8e9d8c8ea43c9b02c"},
+    {file = "grpcio-1.52.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:3bbea65a62ab8a1bc3180aa24dd0d049216856a5c6b470b88769a47bc4b59d8a"},
+    {file = "grpcio-1.52.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7128eaf3c789f7043cdecf7849efb9bb5dddc53f9f753f77613796bf6ea73515"},
+    {file = "grpcio-1.52.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81cc7210dc4735200d81764ad8c3761845a6b95fad36d586fa10cc4f95dc3106"},
+    {file = "grpcio-1.52.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2e85431a3f2970303d34596ae5bd6d07842255f897009b63b23d27b315b6ef69"},
+    {file = "grpcio-1.52.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:71e3185ac3425efc45e7999acba25dc5cc12a8abea46b2dd0f460c50df804974"},
+    {file = "grpcio-1.52.0-cp39-cp39-win32.whl", hash = "sha256:44b326a7ffa56dd44168e067e076121d68a11eeccdcbcf804e9b9bd02e7bc6d8"},
+    {file = "grpcio-1.52.0-cp39-cp39-win_amd64.whl", hash = "sha256:a6329dc693f0ac781219063c4b2c4bedc5519e280fe2f55ce6abc15b05a40d05"},
+    {file = "grpcio-1.52.0.tar.gz", hash = "sha256:a5d4a83d29fc39af429c10b9b326c174fec49b73398e4a966a1f2a4f30aa4fdb"},
 ]
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.51.1)"]
+protobuf = ["grpcio-tools (>=1.52.0)"]
 
 [[package]]
 name = "grpcio-status"
@@ -1158,6 +1158,20 @@ pyparsing = ">=2.2.1"
 python-dateutil = ">=2.7"
 
 [[package]]
+name = "metriq-client"
+version = "0.1.2"
+description = "Python client for metriq API."
+category = "main"
+optional = false
+python-versions = "*"
+files = []
+develop = false
+
+[package.source]
+type = "directory"
+url = "../../metriq-client"
+
+[[package]]
 name = "mpmath"
 version = "1.2.1"
 description = "Python library for arbitrary-precision floating-point arithmetic"
@@ -1206,14 +1220,14 @@ files = [
 
 [[package]]
 name = "mypy-extensions"
-version = "0.4.3"
-description = "Experimental type system extensions for programs checked with the mypy typechecker."
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.5"
 files = [
-    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
-    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
 ]
 
 [[package]]
@@ -1767,14 +1781,14 @@ diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyquil"
-version = "3.3.2"
+version = "3.3.3"
 description = "A Python library for creating Quantum Instruction Language (Quil) programs."
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "pyquil-3.3.2-py3-none-any.whl", hash = "sha256:75c10fb94619190b94bf9456704f3809272a25c74de2372544ddc91a0b7b428f"},
-    {file = "pyquil-3.3.2.tar.gz", hash = "sha256:bda66f2609b41f54bd9a6c3a5f6e007662e07320f1869c9f4568a3b2eac051f0"},
+    {file = "pyquil-3.3.3-py3-none-any.whl", hash = "sha256:4441b5ca0d6217684d341b5dfa147d1655939bfa396a90d0526c793621619560"},
+    {file = "pyquil-3.3.3.tar.gz", hash = "sha256:fc78cc0a099ee115f9b9a52e3d56a6a956328aed407030f19636bbae2fae981a"},
 ]
 
 [package.dependencies]
@@ -1967,18 +1981,18 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "qcs-api-client"
-version = "0.21.2"
+version = "0.21.3"
 description = "A client library for accessing the Rigetti QCS API"
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 files = [
-    {file = "qcs-api-client-0.21.2.tar.gz", hash = "sha256:817c331aeaae6be01cb751c0eede84956c6b141ec31dbf6fc9f5b75959da1d4b"},
-    {file = "qcs_api_client-0.21.2-py3-none-any.whl", hash = "sha256:3f33ccf92a2ad7ef1f2368f7e98181c06aa267fe9817b81a4a3134535d00728c"},
+    {file = "qcs_api_client-0.21.3-py3-none-any.whl", hash = "sha256:4c4592e091c8d5b5796780cf73f6968528a3dc10b5df0ae6a5372658fb3c4360"},
+    {file = "qcs_api_client-0.21.3.tar.gz", hash = "sha256:d219aaef49eb6f515b601467f6c85f20ca52f788d90b3052775e6d12b2f57466"},
 ]
 
 [package.dependencies]
-attrs = ">=20.1.0,<21.0.0"
+attrs = ">=21.3.0,<22.0.0"
 httpx = ">=0.23.0,<0.24.0"
 iso8601 = ">=1.0.2,<2.0.0"
 pydantic = ">=1.7.2,<2.0.0"
@@ -2647,14 +2661,14 @@ files = [
 
 [[package]]
 name = "types-retry"
-version = "0.9.9"
+version = "0.9.9.1"
 description = "Typing stubs for retry"
 category = "main"
 optional = false
 python-versions = "*"
 files = [
-    {file = "types-retry-0.9.9.tar.gz", hash = "sha256:b1087b274680b542c796549e8488898d0b22cd89988ef1016ef56d4367ff4f41"},
-    {file = "types_retry-0.9.9-py3-none-any.whl", hash = "sha256:c5208407527661c37ee826a81abe8e7560e138c8deeccce61bf3f5441f2085f0"},
+    {file = "types-retry-0.9.9.1.tar.gz", hash = "sha256:344ead4387e0e98c6d603758c1318ee4e5b04429cecb9a342a1cf873de3b510d"},
+    {file = "types_retry-0.9.9.1-py3-none-any.whl", hash = "sha256:17d5488b90b803c2ec0b24151c4475fd65abc98a46de19818501e9da4e1c7393"},
 ]
 
 [[package]]
@@ -2688,14 +2702,14 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "websocket-client"
-version = "1.4.2"
+version = "1.5.1"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "websocket-client-1.4.2.tar.gz", hash = "sha256:d6e8f90ca8e2dd4e8027c4561adeb9456b54044312dba655e7cae652ceb9ae59"},
-    {file = "websocket_client-1.4.2-py3-none-any.whl", hash = "sha256:d6b06432f184438d99ac1f456eaf22fe1ade524c3dd16e661142dc54e9cba574"},
+    {file = "websocket-client-1.5.1.tar.gz", hash = "sha256:3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40"},
+    {file = "websocket_client-1.5.1-py3-none-any.whl", hash = "sha256:cdf5877568b7e83aa7cf2244ab56a3213de587bbe0ce9d8b9600fc77b455d89e"},
 ]
 
 [package.extras]
@@ -2785,4 +2799,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "d3ffad4d7d14dbf31136de592f2bdf9895e32bf2d22dbdfeae6dd50fc4fdc51e"
+content-hash = "687728bea33a5a17e930862d44a7f82a21713ccbf1baf5dac0c3433286d1877b"

--- a/benchmark/pyproject.toml
+++ b/benchmark/pyproject.toml
@@ -13,6 +13,7 @@ qiskit = "^0.39.5"
 matplotlib = "^3.6.3"
 cirq = "^1.1.0"
 amazon-braket-sdk = "^1.35.3"
+metriq-client = { git = "https://github.com/unitaryfund/metriq-client.git", branch = "development" }
 
 
 [build-system]

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -1,58 +1,110 @@
 """Run QED-C benchmarks."""
+# Native imports:
+import argparse
 import ast
 import os
 import subprocess
+
+# Third-party imports:
 from git import Repo
 
+# Module imports:
+from metadata import (
+    benchmarks, 
+    metriq_task_name_map, 
+    metriq_platform_name_map,
+)
 
-# Specify path of QED-C repo and where to check it out:
-project_name = "benchmark"
-repo_name = "QC-App-Oriented-Benchmarks"
-git_url = "https://github.com/unitaryfund/QC-App-Oriented-Benchmarks"
-repo_dir = os.path.join(project_name, repo_name)
+# Client for Metriq webapp:
+from metriq import MetriqClient
 
-# If QED-C repo does not exist locally, clone it:
-if os.path.exists(repo_dir):
-    print(f"QED-C benchmarks repository present in {repo_dir}")
-else:
-    print(f"Cloining {git_url} into {repo_dir}...")
-    Repo.clone_from(git_url, repo_dir)
-    print("Clone complete")
 
-# To run this locally, we'll need to change directories:
-dir_path = os.path.dirname(os.path.realpath(__file__))
-os.chdir(os.path.join(dir_path, project_name, repo_name))
+def run_benchmarks(client: MetriqClient):
+    """Run suite of benchmarks from benchmark metadata."""
+    # Process each benchmark:
+    for i, benchmark in enumerate(benchmarks):
+        algorithm = benchmarks[benchmark]["algorithm"]
+        min_qubits = benchmarks[benchmark]["min_qubits"]
+        max_qubits = benchmarks[benchmark]["max_qubits"]
+        num_shots = benchmarks[benchmark]["num_shots"]
+        print(f"Running benchmark {i+1} out of {len(benchmarks)} for {algorithm} with min qubits: {min_qubits}, max_qubits: {max_qubits}, and num_shots: {num_shots}.")
 
-# Run the specified algorithms over the list of provider offerings:
-benchmarks = {
-    "1" : {
-        "algorithm": "quantum-fourier-transform",
-        "providers": [
-            {"qiskit": "qasm_simulator"}
-        ]
-    }
-}
+        providers = benchmarks[benchmark]["providers"]
+        for provider in providers:
+            for environment, device in provider.items():
+                benchmark_script = [f for f in os.listdir(os.path.join(algorithm, environment)) if f.endswith('_benchmark.py')][0]
 
-# Process each benchmark:
-for benchmark in benchmarks:
-    algorithm = benchmarks[benchmark]["algorithm"]
-    print(f"Running benchmark for {algorithm}...")
+                # Run each benchmark script with command line args:
+                result = subprocess.run(
+                    ["python", 
+                    f"{os.path.join(algorithm, environment, benchmark_script)}", 
+                    "-backend_id", f"{device}",
+                    "-min_qubits", f"{min_qubits}",
+                    "-max_qubits", f"{max_qubits}",
+                    "-num_shots", f"{num_shots}",
+                    ],
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+                try:
+                    # Data obtained is a string, so interpret as dictionary and store in benchmarking dictionary.
+                    data = ast.literal_eval(result.stdout.decode("utf8").split("\n")[-2])
+                    print(data)
+                    data["algorithm"] = algorithm
+                    data["device"] = device
+                    process_data_for_metriq(data, client)
+                except:
+                    print(f"No data for {algorithm} running on {device}")
 
-    providers = benchmarks[benchmark]["providers"]
-    for provider in providers:
-        for environment, device in provider.items():
-            benchmark_script = [f for f in os.listdir(os.path.join(algorithm, environment)) if f.endswith('_benchmark.py')][0]
 
-            # Run each benchmark script with command line args:
-            result = subprocess.run(
-                ["python", f"{os.path.join(algorithm, environment, benchmark_script)}", "-backend_id", f"{device}"],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            )
+def process_data_for_metriq(data: dict, client: MetriqClient):
+    """Process data obtained from QED-C benchmark script."""
+    task_name = metriq_task_name_map.get(data["algorithm"])["name"]
+    device_name = metriq_platform_name_map.get(data["device"])["name"]
 
-            # Data obtained is a string, so interpret as dictionary and store in benchmarking dictionary.
-            data = ast.literal_eval(result.stdout.decode("utf8").split("\n")[-2])
-            print(data)
+    for i, qubit in enumerate(data["groups"]):
+        metriq_payload = {
+            "task": task_name,
+            "method": device_name,
+            "platform": device_name,
+            "metric": "Fidelity",
+            "value": data["avg_fidelities"][i],
+            "qubits": qubit,
+        }
+        try:
+            # Upload benchmark result to Metriq:
+            print(f"Uploading: {metriq_payload}")
+            # Leaving this deliberately commented out as do not want to modify Metriq post at this time.
+            #client.submission_
+        except:
+            # Unable to upload benchmark data to Metriq:
+            print(f"Unable to upload {metriq_payload}")
 
-            # TODO: At this point, we would have some Metriq API call that would
-            # take the data object and insert it into the QED-C submission on
-            # Metriq.
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run benchmarking.")
+    parser.add_argument("-token", help="Bearer token for Metriq API.", type=str)
+
+    # Specify path of QED-C repo and where to check it out:
+    project_name = "benchmark"
+    repo_name = "QC-App-Oriented-Benchmarks"
+    git_url = "https://github.com/unitaryfund/QC-App-Oriented-Benchmarks"
+    repo_dir = os.path.join(project_name, repo_name)
+
+    # If QED-C repo does not exist locally, clone it:
+    if os.path.exists(repo_dir):
+        print(f"QED-C benchmarks repository present in {repo_dir}")
+    else:
+        print(f"Cloining {git_url} into {repo_dir}...")
+        Repo.clone_from(git_url, repo_dir)
+        print("Clone complete")
+
+    # To run this locally, we'll need to change directories:
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(os.path.join(dir_path, project_name, repo_name))
+
+    args = parser.parse_args()
+    token = args.token
+    client = MetriqClient(url="https://metriq.info", token=token)
+    run_benchmarks(client)
+


### PR DESCRIPTION
The `metadata.py` file contains all of the benchmarks one wishes to specify/run. At this time, QFT is the only supported QED-C algorithm, but this can be extended.

To run, consult the README.md file in the `benchmark/` directory.

In essence, running:

```
python run.py -token <TOKEN_ID>
```

where `<TOKEN_ID>` is the Metriq API token will yield something like:

```
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.889, 'qubits': '2'}
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.571, 'qubits': '3'}
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.467, 'qubits': '4'}
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.226, 'qubits': '5'}
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.323, 'qubits': '6'}
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.202, 'qubits': '7'}
Uploading: {'task': 'Quantum Fourier transform', 'method': 'qasm-simulator', 'platform': 'qasm-simulator', 'metric': 'Fidelity', 'value': 0.0, 'qubits': '8'}
```

Obviously no uploading happens now as the `metriq-client` needs to be updated/fixed/etc., but it has the data in the proper form and is technically ready. 