### PR TITLE
#815: results shots metadata

### DIFF
--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
     if os.path.exists(repo_dir):
         print(f"QED-C benchmarks repository present in {repo_dir}")
     else:
-        print(f"Cloining {git_url} into {repo_dir}...")
+        print(f"Cloning {git_url} into {repo_dir}...")
         Repo.clone_from(git_url, repo_dir)
         print("Clone complete")
 

--- a/metriq-api/migrations/013-815_ResultShotsMetadata.js
+++ b/metriq-api/migrations/013-815_ResultShotsMetadata.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('results', 'shots',
+          {
+            type: Sequelize.INTEGER,
+            allowNull: true
+          }, { transaction: t })
+      ])
+    })
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.removeColumn('results', 'shots')
+      ])
+    })
+  }
+}

--- a/metriq-api/models/resultModel.js
+++ b/metriq-api/models/resultModel.js
@@ -38,6 +38,10 @@ module.exports = function (sequelize, DataTypes) {
     circuitDepth: {
       type: DataTypes.INTEGER,
       allowNull: true
+    },
+    shots: {
+      type: DataTypes.INTEGER,
+      allowNull: true
     }
   }, {})
   Model.associate = function (db) {

--- a/metriq-api/service/resultService.js
+++ b/metriq-api/service/resultService.js
@@ -165,6 +165,7 @@ class ResultService extends ModelService {
     result.sampleSize = reqBody.sampleSize
     result.qubitCount = reqBody.qubitCount
     result.circuitDepth = reqBody.circuitDepth
+    result.shots = reqBody.shots
 
     const nResult = await this.create(result)
     if (!nResult.success) {
@@ -222,6 +223,7 @@ class ResultService extends ModelService {
     result.sampleSize = reqBody.sampleSize
     result.qubitCount = reqBody.qubitCount
     result.circuitDepth = reqBody.circuitDepth
+    result.shots = reqBody.shots
 
     result.save()
 


### PR DESCRIPTION
Per unitaryfund/metriq-api#815, adding a "shots" field to results metadata, (back end)